### PR TITLE
Fix docker build with uppercase names

### DIFF
--- a/.github/actions/variables/action.yml
+++ b/.github/actions/variables/action.yml
@@ -86,8 +86,9 @@ runs:
 
     - name: Populate environment variables
       run: |
-        INPUT_SHA=${{ inputs.SHA }}
         REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
+        IMAGE_PREFIX=$(echo "docker.pkg.github.com/${{ github.repository }}/${REPO}" | tr '[:upper:]' '[:lower:]')
+        INPUT_SHA=${{ inputs.SHA }}
         IMAGE_TAG=${INPUT_SHA:-${SHA}}
         touch .env
         ORIGINAL_VARS=`cat .env`
@@ -95,8 +96,8 @@ runs:
         echo "### Defaults ###" >> .env
         echo "NODE_ENV=production" >> .env
         echo "HOST_NAME=${SSH_HOST}" >> .env
-        echo "BACKEND_IMAGE=docker.pkg.github.com/${{ github.repository }}/${REPO}-backend" >> .env
-        echo "FRONTEND_IMAGE=docker.pkg.github.com/${{ github.repository }}/${REPO}-frontend" >> .env
+        echo "BACKEND_IMAGE=${IMAGE_PREFIX}-backend" >> .env
+        echo "FRONTEND_IMAGE=${IMAGE_PREFIX}-frontend" >> .env
         echo "IMAGE_TAG=${IMAGE_TAG:0:7}" >> .env
         echo "" >> .env
         echo "${ORIGINAL_VARS}" >> .env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "CI"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ Re-deploys can also be manually triggered (e.g. reverting to a previous build) b
 
 Please note that github actions and github packages have limits for free accounts and are paid services. Check [github pricing](https://github.com/pricing) for details.
 
+If you want to avoid running the CI/CD workflow on a commit (e.g. after updating a markdown file), include `[skip ci]` or `[ci skip]` to the commit message.
+
 To limit usage of github packages storage in private repos, only the latest 10 versions of each docker image are kept, and older ones are deleted. This behaviour [can be configured](./.github/workflows/delete-old-images.yml). Packages for public repos are free and [cannot be deleted](https://docs.github.com/en/free-pro-team@latest/packages/publishing-and-managing-packages/deleting-a-package#about-public-package-deletion).
 
 ### Server Setup

--- a/sample.env
+++ b/sample.env
@@ -39,6 +39,6 @@
 # MAIL_FROM_ADDRESS=
 
 ### DOCKER ###
-# BACKEND_IMAGE=docker.pkg.github.com/owner/repo/backend
-# FRONTEND_IMAGE=docker.pkg.github.com/owner/repo/frontend
+# BACKEND_IMAGE=docker.pkg.github.com/{owner}/{repo}/{repo}-backend
+# FRONTEND_IMAGE=docker.pkg.github.com/{owner}/{repo}/{repo}-frontend
 # IMAGE_TAG=latest


### PR DESCRIPTION
Docker build fails in repos with uppercase letters (owner or repo)

This fixes that by converting the image names to lowercase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hatemhosny/parse-starter/2)
<!-- Reviewable:end -->
